### PR TITLE
provide Docker setup for those who don't have node installed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+test
+webpage
+.gitignore
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:8.17.0-jessie
+
+ENV ANSIBLE_INVENTORY=/app/inventory.conf
+
+RUN mkdir /app
+WORKDIR /app
+COPY . /app/
+
+RUN cd /app && npm install
+
+CMD /usr/local/bin/node ./main.js -c ${ANSIBLE_INVENTORY}

--- a/README.md
+++ b/README.md
@@ -2,4 +2,32 @@
 
 You can already check out the example inventories within this project. To browse through the pregenerated data just clone this repo and open the [/webpage/index.html](/webpage/index.html)
 
-To generate your own JSON data **'```node ./main.js -c YOUR_CONFIG_FILE```'**. After generating the data you can browse it through on the webpage: [/webpage/index.html](/webpage/index.html)
+To generate your own JSON data **```node ./main.js -c YOUR_CONFIG_FILE```**. After generating the data you can browse it through on the webpage: [/webpage/index.html](/webpage/index.html)
+
+## Running in Docker
+
+For those of you who don't have `node` installed on their machine, you can run everything inside a Docker container.
+
+First *build* the container for the inventory browser via
+
+```bash
+docker build  -t ansible-inventory-browser .
+```
+
+You can then *run* the container to generate the data (as a one-off command) via
+
+```bash
+docker run -it \
+    -v $(pwd)/webpage/generated-data:/app/webpage/generated-data:rw \
+    -v $(pwd):/conf \
+    -e ANSIBLE_INVENTORY=/conf/inventory.conf \
+    ansible-inventory-browser
+```
+
+where
+
+* `-v $(pwd)/webpage/generated-data:/app/webpage/generated-data:rw` mounts the directory with the generated data to be shown in the browser
+* `-v $(pwd):/conf` mounts the current directory to access the inventory config file
+* `-e ANSIBLE_INVENTORY=/conf/inventory.conf` points to the config file inside the container
+
+Afterwards, you can open `webpage/index.html` from your local machine in your browser.

--- a/inventory.conf
+++ b/inventory.conf
@@ -19,14 +19,14 @@
     },
     "inventory-config": [
         {
-            "dir": "example-inventories\\inventory1",
+            "dir": "example-inventories/inventory1",
             "env": "env1",
             "shortcuts": [
                 { "resource-type": "group", "name": "host-count", "path": "hostnames", "function": "count"}
             ]
         },
         {
-            "dir": "example-inventories\\inventory2",
+            "dir": "example-inventories/inventory2",
             "env": "env2",
             "hosts-file-format": "ini",
             "shortcuts": [
@@ -35,7 +35,7 @@
             ]
         },
         {
-            "dir": "example-inventories\\inventory3",
+            "dir": "example-inventories/inventory3",
             "env": "env3",
             "hosts-file-format": "yaml",
             "shortcuts": [
@@ -44,7 +44,7 @@
             ]
         },
         {
-            "dir": "example-inventories\\inventory4",
+            "dir": "example-inventories/inventory4",
             "env": "env4",
             "shortcuts": [
                 { "resource-type": "host",  "name": "IPv4-Address",  "path": "variables/ansible_host", "function": "copy"},
@@ -52,7 +52,7 @@
             ]
         },
         {
-            "dir": "example-inventories\\inventory5",
+            "dir": "example-inventories/inventory5",
             "env": "env5",
             "hosts-file-format": "yaml",
             "shortcuts": [


### PR DESCRIPTION
Hi @grimmpp,

I wanted to try your inventory browser, but didn't have `node` installed on my machine... therefore, I created a Docker setup that allows you to run everything in a container. The `README` should contain all details.

Besides I had to change the path separator in the `inventory.conf` - hope it still works like that on a Windows machine...

For convenience, I think it would be cool to actually start a node server, that statically serves the `index.html`. Like that one would only need to forward the `node` port from the container and there is no need to mount the `webpage` directory... it could then also watch the inventory files and re-create the webpage upon changes...

You should definitely show this to Tomek, Dimi and Flo, it might help them to keep overview over their Ansible environments.

Besides, I'm wondering whether [Ansible Tower](https://docs.ansible.com/ansible-tower/latest/html/userguide/inventories.html) offers such a feature... but AFAIK it is not for free.

Best,

Michael